### PR TITLE
Skip proctor authorization at end if use_grade_proctor is "No"

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -802,15 +802,6 @@ sub pre_header_initialize {
 				$cleanSet->version_last_attempt_time($set->version_last_attempt_time);
 				$cleanSet->version_time_limit($set->version_time_limit);
 				$cleanSet->attempts_per_version($set->attempts_per_version);
-
-				# If configured to not use grade proctor authorization, convert the
-				# version set to a normal gateway quiz so it can be accessed and
-				# graded without proctor authentication.
-				if ($set->assignment_type eq 'proctored_gateway' && $set->use_grade_proctor eq 'No') {
-					$self->{assignment_type} = 'gateway';
-					$set->assignment_type('gateway');
-					eval { $db->deleteAllProctorKeys($effectiveUserName); }
-				}
 				$cleanSet->assignment_type($set->assignment_type);
 				$db->putSetVersion($cleanSet);
 


### PR DESCRIPTION
In that case that user_grade_proctor is "No" instead of changing the assignment type from 'proctored_gateway' to 'gateway' the first time that proctor authorization has been obtained, skip obtaining proctor authorization when "Grade Test" is hit.  This means that if the user leaves the quiz for any reason the user will still need proctor authorization again to re-enter the quiz.  However, when the user hits "Grade Test" the test will just be graded without the need of proctor authorization.