### PR TITLE
Suggestions and fixes.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -238,6 +238,17 @@ $pg{options}{periodicRandomizationPeriod} = 5;
 $pg{options}{showCorrectOnRandomize} = 0;
 
 ################################################################################
+# Single Problem Grader
+################################################################################
+# When using the single problem grader, should the problem score be entered in as
+#   Percent - Percent value
+#   Point   - Point value
+#   Both    - Show inputs for both percent and point values.
+# Note, the problem score is always saved as a percent, so point values will be
+# rounded to the nearest whole percent.
+$problemGraderScore = 'Percent';
+
+################################################################################
 # Waive Explanations
 ################################################################################
 # switch to remove explanation essay block from questions that have one
@@ -1982,6 +1993,17 @@ $ConfigValues = [
 					. 'Set this to -1 to hide hints.  Note that this can be overridden with a per problem setting.'
 			),
 			type => 'number'
+		},
+		{
+			var  => 'problemGraderScore',
+			doc  => x('Method to enter problem scores in the single problem manual grader'),
+			doc2 => x(
+				'This configures if the single problem manual grader has inputs to enter problem scores as a percent, '
+					. 'a point value, or both. Note, the problem score is always saved as a percent, so when '
+					. 'using a point value, the problem score will be rounded to the nearest whole percent.'
+			),
+			values => [qw(Percent Point Both)],
+			type   => 'popuplist'
 		},
 	],
 	[

--- a/htdocs/js/apps/ProblemGrader/problemgrader.js
+++ b/htdocs/js/apps/ProblemGrader/problemgrader.js
@@ -1,10 +1,6 @@
 'use strict';
 
 (() => {
-	const roundPointValue = (pointValue, score) => {
-		pointValue.value = (Math.round((score * pointValue.max / 100) / pointValue.step) * pointValue.step).toFixed(2);
-	};
-
 	// Comment preview popovers.
 	document.querySelectorAll('.preview').forEach((el) => {
 		el.addEventListener('click', () => {
@@ -33,6 +29,9 @@
 		})
 	);
 
+	const setPointInputValue = (pointInput, score) =>
+		pointInput.value = (Math.round(score * pointInput.max / 100 / pointInput.step) * pointInput.step).toFixed(2);
+
 	// Compute the problem score from any answer sub scores, and update the problem score input.
 	document.querySelectorAll('.answer-part-score').forEach((part) => {
 		part.addEventListener('input', () => {
@@ -51,24 +50,24 @@
 				});
 				document.getElementById(`score_problem${problemId}`).value = Math.round(score);
 
-				const pointValue = document.getElementById(`score_problem${problemId}_points`);
-				if (pointValue) roundPointValue(pointValue, score);
+				const pointInput = document.getElementById(`score_problem${problemId}_points`);
+				if (pointInput) setPointInputValue(pointInput, score);
 			}
 			document.getElementById(`grader_messages_problem${problemId}`).innerHTML = '';
 		});
 	});
 
 	// Update problem score if point value changes and is a valid value.
-	document.querySelectorAll('.problem-points').forEach((points) => {
-		points.addEventListener('input', () => {
-			const problemId = points.dataset.problemId;
-			if (points.checkValidity()) {
-				const problemScore = document.getElementById(`score_problem${problemId}`);
-				points.classList.remove('is-invalid');
-				problemScore.classList.remove('is-invalid');
-				problemScore.value = Math.round(100 * points.value / points.max);
+	document.querySelectorAll('.problem-points').forEach((pointInput) => {
+		pointInput.addEventListener('input', () => {
+			const problemId = pointInput.dataset.problemId;
+			if (pointInput.checkValidity()) {
+				const scoreInput = document.getElementById(`score_problem${problemId}`);
+				pointInput.classList.remove('is-invalid');
+				scoreInput.classList.remove('is-invalid');
+				scoreInput.value = Math.round(100 * pointInput.value / pointInput.max);
 			} else {
-				points.classList.add('is-invalid');
+				pointInput.classList.add('is-invalid');
 			}
 			document.getElementById(`grader_messages_problem${problemId}`).innerHTML = '';
 		});
@@ -84,10 +83,10 @@
 				el.classList.remove('is-invalid');
 
 				if (el.classList.contains('problem-score')) {
-					const pointValue = document.getElementById(`score_problem${problemId}_points`);
-					if (pointValue) {
-						pointValue.classList.remove('is-invalid');
-						roundPointValue(pointValue, el.value);
+					const pointInput = document.getElementById(`score_problem${problemId}_points`);
+					if (pointInput) {
+						pointInput.classList.remove('is-invalid');
+						setPointInputValue(pointInput, el.value);
 					}
 				}
 			}
@@ -156,14 +155,15 @@
 								if (scoreCell.dataset.problemId == saveData.problemId) {
 									scoreCell.textContent = scoreInput.value == '100' ? '\u{1F4AF}' : scoreInput.value;
 								}
-								testValue += document.gwquiz.elements['probstatus' + scoreCell.dataset.problemId].value *
-									scoreCell.dataset.problemValue;
+								testValue += document.gwquiz.elements['probstatus'
+									+ scoreCell.dataset.problemId].value * scoreCell.dataset.problemValue;
 							}
 							const recordedScore = document.getElementById('test-recorded-score');
 							if (recordedScore) {
 								recordedScore.textContent = Math.round(100 * testValue / 2) / 100;
 								document.getElementById('test-recorded-percent').textContent =
-									Math.round(100 * testValue / (2 * document.getElementById('test-total-possible').textContent));
+									Math.round(100 * testValue /
+										(2 * document.getElementById('test-total-possible').textContent));
 							}
 						}
 

--- a/htdocs/js/apps/ProblemGrader/problemgrader.js
+++ b/htdocs/js/apps/ProblemGrader/problemgrader.js
@@ -1,6 +1,10 @@
 'use strict';
 
 (() => {
+	const roundPointValue = (pointValue, score) => {
+		pointValue.value = (Math.round((score * pointValue.max / 100) / pointValue.step) * pointValue.step).toFixed(2);
+	};
+
 	// Comment preview popovers.
 	document.querySelectorAll('.preview').forEach((el) => {
 		el.addEventListener('click', () => {
@@ -48,7 +52,7 @@
 				document.getElementById(`score_problem${problemId}`).value = Math.round(score);
 
 				const pointValue = document.getElementById(`score_problem${problemId}_points`);
-				if (pointValue) pointValue.value = Math.round(score * pointValue.max / 10) / 10;
+				if (pointValue) roundPointValue(pointValue, score);
 			}
 			document.getElementById(`grader_messages_problem${problemId}`).innerHTML = '';
 		});
@@ -83,7 +87,7 @@
 					const pointValue = document.getElementById(`score_problem${problemId}_points`);
 					if (pointValue) {
 						pointValue.classList.remove('is-invalid');
-						pointValue.value = Math.round(el.value * pointValue.max / 10) / 10;
+						roundPointValue(pointValue, el.value);
 					}
 				}
 			}

--- a/htdocs/js/apps/ProblemGrader/problemgrader.js
+++ b/htdocs/js/apps/ProblemGrader/problemgrader.js
@@ -145,12 +145,22 @@
 					} else {
 						// Update the hidden problem status fields and score table for gateway quizzes
 						if (saveData.versionId !== '0') {
-							for (const scoreCell of document.querySelectorAll(
-								`table.gwNavigation td.score[data-problem-id="${saveData.problemId}"]`)) {
-								scoreCell.textContent = scoreInput.value == '100' ? '\u{1F4AF}' : scoreInput.value;
-							}
 							document.gwquiz.elements['probstatus' + saveData.problemId].value =
 								parseInt(scoreInput.value) / 100;
+							let testValue = 0;
+							for (const scoreCell of document.querySelectorAll('table.gwNavigation td.score')) {
+								if (scoreCell.dataset.problemId == saveData.problemId) {
+									scoreCell.textContent = scoreInput.value == '100' ? '\u{1F4AF}' : scoreInput.value;
+								}
+								testValue += document.gwquiz.elements['probstatus' + scoreCell.dataset.problemId].value *
+									scoreCell.dataset.problemValue;
+							}
+							const recordedScore = document.getElementById('test-recorded-score');
+							if (recordedScore) {
+								recordedScore.textContent = Math.round(100 * testValue / 2) / 100;
+								document.getElementById('test-recorded-percent').textContent =
+									Math.round(100 * testValue / (2 * document.getElementById('test-total-possible').textContent));
+							}
 						}
 
 						if (saveData.pastAnswerId !== '0') {

--- a/htdocs/js/apps/ProblemGrader/problemgrader.js
+++ b/htdocs/js/apps/ProblemGrader/problemgrader.js
@@ -35,15 +35,37 @@
 			const problemId = part.dataset.problemId;
 			const answerLabels = JSON.parse(part.dataset.answerLabels);
 
-			if (!part.checkValidity()) part.classList.add('is-invalid');
-			else part.classList.remove('is-invalid');
+			if (!part.checkValidity()) {
+				part.classList.add('is-invalid');
+			} else {
+				part.classList.remove('is-invalid');
 
-			let score = 0;
-			answerLabels.forEach((label) => {
-				const partElt = document.getElementById(`score_problem${problemId}_${label}`);
-				score += partElt.value * partElt.dataset.weight;
-			});
-			document.getElementById(`score_problem${problemId}`).value = Math.round(score);
+				let score = 0;
+				answerLabels.forEach((label) => {
+					const partElt = document.getElementById(`score_problem${problemId}_${label}`);
+					score += partElt.value * partElt.dataset.weight;
+				});
+				document.getElementById(`score_problem${problemId}`).value = Math.round(score);
+
+				const pointValue = document.getElementById(`score_problem${problemId}_points`);
+				if (pointValue) pointValue.value = Math.round(score * pointValue.max / 10) / 10;
+			}
+			document.getElementById(`grader_messages_problem${problemId}`).innerHTML = '';
+		});
+	});
+
+	// Update problem score if point value changes and is a valid value.
+	document.querySelectorAll('.problem-points').forEach((points) => {
+		points.addEventListener('input', () => {
+			const problemId = points.dataset.problemId;
+			if (points.checkValidity()) {
+				const problemScore = document.getElementById(`score_problem${problemId}`);
+				points.classList.remove('is-invalid');
+				problemScore.classList.remove('is-invalid');
+				problemScore.value = Math.round(100 * points.value / points.max);
+			} else {
+				points.classList.add('is-invalid');
+			}
 			document.getElementById(`grader_messages_problem${problemId}`).innerHTML = '';
 		});
 	});
@@ -51,9 +73,20 @@
 	// Clear messages when the score or comment are changed.
 	document.querySelectorAll('.problem-score,.grader-problem-comment').forEach((el) => {
 		el.addEventListener('input', () => {
-			if (!el.checkValidity()) el.classList.add('is-invalid');
-			else el.classList.remove('is-invalid');
+			const problemId = el.dataset.problemId;
+			if (!el.checkValidity()) {
+				el.classList.add('is-invalid');
+			} else {
+				el.classList.remove('is-invalid');
 
+				if (el.classList.contains('problem-score')) {
+					const pointValue = document.getElementById(`score_problem${problemId}_points`);
+					if (pointValue) {
+						pointValue.classList.remove('is-invalid');
+						pointValue.value = Math.round(el.value * pointValue.max / 10) / 10;
+					}
+				}
+			}
 			document.getElementById(`grader_messages_problem${el.dataset.problemId}`).innerHTML = '';
 		});
 	});

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -956,6 +956,8 @@ span {
 		&.alert-success, &.alert-danger {
 			transition: none;
 			border-radius: 3px;
+			color: var(--bs-alert-color);
+			background-color: var(--bs-alert-bg);
 		}
 	}
 

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -960,6 +960,7 @@ span {
 	}
 
 	.problem-score,
+	.problem-points,
 	.answer-part-score {
 		width: 5.5rem;
 	}

--- a/lib/WeBWorK/HTML/SingleProblemGrader.pm
+++ b/lib/WeBWorK/HTML/SingleProblemGrader.pm
@@ -31,12 +31,13 @@ use WeBWorK::Utils 'wwRound';
 sub new ($class, $c, $pg, $userProblem) {
 	$class = ref($class) || $class;
 
-	my $db        = $c->db;
-	my $courseID  = $c->stash('courseID');
-	my $setID     = $userProblem->set_id;
-	my $versionID = ref($userProblem) =~ /::ProblemVersion/ ? $userProblem->version_id : 0;
-	my $studentID = $userProblem->user_id;
-	my $problemID = $userProblem->problem_id;
+	my $db           = $c->db;
+	my $courseID     = $c->stash('courseID');
+	my $setID        = $userProblem->set_id;
+	my $versionID    = ref($userProblem) =~ /::ProblemVersion/ ? $userProblem->version_id : 0;
+	my $studentID    = $userProblem->user_id;
+	my $problemID    = $userProblem->problem_id;
+	my $problemValue = $userProblem->value;
 
 	# Get the currently saved score.
 	my $recordedScore = $userProblem->status;
@@ -52,6 +53,7 @@ sub new ($class, $c, $pg, $userProblem) {
 		course_id      => $courseID,
 		student_id     => $studentID,
 		problem_id     => $problemID,
+		problem_value  => $problemValue,
 		set_id         => $setID,
 		version_id     => $versionID,
 		recorded_score => $recordedScore,

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -174,8 +174,14 @@
 	% )
 	% {
 		<div class="gwMessage">
-			<%= maketext('The recorded score for this version is  [_1]/[_2].',
-				wwRound(2, $c->{recordedScore}), $c->{totalPossible}) =%>
+			<%== maketext(
+				'Your recorded score for this version is [_1]/[_2] ([_3]%).',
+				'<span id="test-recorded-score">' . wwRound(2, $c->{recordedScore}) . '</span>',
+				'<span id="test-total-possible">' . $c->{totalPossible} . '</span>',
+				'<span id="test-recorded-percent">'
+					. wwRound(0, 100 * $c->{recordedScore} / $c->{totalPossible})
+					. '</span>'
+			) =%>
 		</div>
 	% }
 % } elsif ($c->{will}{checkAnswers}) {
@@ -186,8 +192,14 @@
 					$c->{attemptScore}, $c->{totalPossible}) =%>
 			</strong>
 			<br>
-			<%= maketext('The recorded score for this version is [_1]/[_2].',
-				wwRound(2, $c->{recordedScore}), $c->{totalPossible}) =%>
+			<%== maketext(
+				'Your recorded score for this version is [_1]/[_2] ([_3]%).',
+				'<span id="test-recorded-score">' . wwRound(2, $c->{recordedScore}) . '</span>',
+				'<span id="test-total-possible">' . $c->{totalPossible} . '</span>',
+				'<span id="test-recorded-percent">'
+					. wwRound(0, 100 * $c->{recordedScore} / $c->{totalPossible})
+					. '</span>'
+			) =%>
 		</div>
 	% }
 % }
@@ -299,8 +311,15 @@
 	% if (!$c->{checkAnswers} && !$c->{submitAnswers} && $c->{can}{showScore}) {
 		<div class="gwMessage">
 			<strong>
-				<%= maketext('Your recorded score on this test (version [_1]) is [_2]/[_3].',
-					$setVersionID, wwRound(2, $c->{recordedScore}), $c->{totalPossible})
+				<%== maketext(
+						'Your recorded score on this test (version [_1]) is [_2]/[_3] ([_4]%).',
+						$setVersionID,
+						'<span id="test-recorded-score">' . wwRound(2, $c->{recordedScore}) . '</span>',
+						'<span id="test-total-possible">' . $c->{totalPossible} . '</span>',
+						'<span id="test-recorded-percent">'
+							. wwRound(0, 100 * $c->{recordedScore} / $c->{totalPossible})
+							. '</span>'
+					)
 					. (
 						$c->{exceededAllowedTime} && $c->{recordedScore} == 0
 						? ' ' . maketext('You exceeded the allowed time.')
@@ -392,7 +411,8 @@
 				</td>
 			% end
 			% content_for 'gw-navigation-score-row' => begin
-				<td class="score" data-problem-id="<%= $problems->[ $probOrder->[$i] ]->problem_id %>">
+				<td class="score" data-problem-id="<%= $problems->[ $probOrder->[$i] ]->problem_id %>"
+					data-problem-value="<%= $problems->[ $probOrder->[$i] ]->value %>">
 					% if ($c->{probStatus}[ $probOrder->[$i] ] == 1) {
 						&#128175;
 					% } else {

--- a/templates/HTML/SingleProblemGrader/grader.html.ep
+++ b/templates/HTML/SingleProblemGrader/grader.html.ep
@@ -61,8 +61,8 @@
 			% }
 		% }
 
-		% # Total point value. Hide unless point value > 1.
-		% if ($grader->{problem_value} > 1) {
+		% # Total point value. Show only if configured to.
+		% unless ($ce->{problemGraderScore} eq 'Percent') {
 			<div class="row align-items-center mb-2">
 				<%= label_for "score_problem$grader->{problem_id}_points",
 					class => 'col-fixed col-form-label',
@@ -72,10 +72,19 @@
 						class => 'help-popup',
 						data => {
 							bs_content => maketext(
-								'The initial value is the total number points for the answer(s) that are '
-								. 'currently shown.  If this is modified, it will be used to compute the '
-								. 'total problem score below.  This score is not saved, and will be reset '
-								. 'to the score for the shown answer(s) if the page is reloaded.'
+								'The initial value is the currently saved score as a point value computed '
+								. 'using the percent score.  This point value is used to compute the percent '
+								. 'score (rounded to a whole percent) that can be saved.'
+							)
+							. (
+								@{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER} } > 1
+								? ' '
+								. maketext(
+									'This can computed from the answer sub scores above using the weights shown '
+									. 'if they are modified.  Alternatively, enter the point score you want '
+									. 'saved here (the above sub scores will be ignored).'
+								)
+								: ''
 							),
 							bs_placement => 'top',
 							bs_toggle    => 'popover'
@@ -99,8 +108,12 @@
 			</div>
 		% }
 
-		% # Total problem score
-		<div class="row align-items-center mb-2">
+		% # Total problem score. Hide if configured to only show point values.
+		% if ($ce->{problemGraderScore} eq 'Point') {
+			<div class="row align-items-center mb-2 d-none">
+		% } else {
+			<div class="row align-items-center mb-2">
+		% }
 			<%= label_for "score_problem$grader->{problem_id}",
 				class => 'col-fixed col-form-label',
 				begin =%>

--- a/templates/HTML/SingleProblemGrader/grader.html.ep
+++ b/templates/HTML/SingleProblemGrader/grader.html.ep
@@ -63,6 +63,23 @@
 
 		% # Total point value. Show only if configured to.
 		% unless ($ce->{problemGraderScore} eq 'Percent') {
+			% # Compute a reasonable step size based on point value.
+			% # First use some preset nice values, the only use whole
+			% # point values, such that the step size >= 1% of total.
+			% my $stepSize;
+			% if ($grader->{problem_value} == 1) {
+				% $stepSize = 0.01;
+			% } elsif ($grader->{problem_value} <= 5) {
+				% $stepSize = 0.05;
+			% } elsif ($grader->{problem_value} <= 10) {
+				% $stepSize = 0.1;
+			% } elsif ($grader->{problem_value} <= 25) {
+				% $stepSize = 0.25;
+			% } elsif ($grader->{problem_value} <= 50) {
+				% $stepSize = 0.5;
+			% } else {
+				% $stepSize = int(($grader->{problem_value} - 1) / 100) + 1;
+			% }
 			<div class="row align-items-center mb-2">
 				<%= label_for "score_problem$grader->{problem_id}_points",
 					class => 'col-fixed col-form-label',
@@ -99,7 +116,7 @@
 					<%= number_field 'grader-problem-points' => '',
 						min          => 0,
 						max          => $grader->{problem_value},
-						step         => 0.1,
+						step         => $stepSize,
 						autocomplete => 'off',
 						id           => "score_problem$grader->{problem_id}_points",
 						class        => "problem-points form-control form-control-sm d-inline",

--- a/templates/HTML/SingleProblemGrader/grader.html.ep
+++ b/templates/HTML/SingleProblemGrader/grader.html.ep
@@ -125,51 +125,51 @@
 			</div>
 		% }
 
-		% # Total problem score. Hide if configured to only show point values.
+		% # Total problem score. (Hidden if configured to only show point values.)
 		% if ($ce->{problemGraderScore} eq 'Point') {
-			<div class="row align-items-center mb-2 d-none">
+			<%= hidden_field 'grader-problem-score' => wwRound(0, $grader->{recorded_score} * 100),
+				id   => "score_problem$grader->{problem_id}",
+				data => { problem_id => $grader->{problem_id} } =%>
 		% } else {
 			<div class="row align-items-center mb-2">
-		% }
-			<%= label_for "score_problem$grader->{problem_id}",
-				class => 'col-fixed col-form-label',
-				begin =%>
-				<%= maketext('Problem Score (%):') %>
-				<%= link_to '#',
-					class => 'help-popup',
-					data => {
-						bs_content =>
-						maketext('The initial value is the currently saved score for this student.')
-						. (
-							@{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER} } > 1
-							? ' '
-							. maketext(
-								'This is the only part of the score that is actually saved. '
-								. 'This is computed from the answer sub scores above using the weights shown if they '
-								. 'are modified.  Alternatively, enter the score you want saved here '
-								. '(the above sub scores will be ignored).'
-							)
-							: ''
-						),
-						bs_placement => 'top',
-						bs_toggle    => 'popover'
-					},
-					begin =%>
-					<i class="icon fas fa-question-circle" aria-hidden="true" data-alt="Help Icon"></i>
-					<span class="sr-only-glyphicon">Help Icon</span>
+				<%= label_for "score_problem$grader->{problem_id}", class => 'col-fixed col-form-label', begin =%>
+					<%= maketext('Problem Score (%):') %>
+					<%= link_to '#',
+						class => 'help-popup',
+						data => {
+							bs_content =>
+							maketext('The initial value is the currently saved score for this student.')
+							. (
+								@{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER} } > 1
+								? ' '
+								. maketext(
+									'This is the only part of the score that is actually saved. '
+									. 'This is computed from the answer sub scores above using the weights shown if '
+									. 'they are modified.  Alternatively, enter the score you want saved here '
+									. '(the above sub scores will be ignored).'
+								)
+								: ''
+							),
+							bs_placement => 'top',
+							bs_toggle    => 'popover'
+						},
+						begin =%>
+						<i class="icon fas fa-question-circle" aria-hidden="true" data-alt="Help Icon"></i>
+						<span class="sr-only-glyphicon">Help Icon</span>
+					<% end =%>
 				<% end =%>
-			<% end =%>
-			<div class="col-sm">
-				% param('grader-problem-score', wwRound(0, $grader->{recorded_score} * 100));
-				<%= number_field 'grader-problem-score' => '',
-					min          => 0,
-					max          => 100,
-					autocomplete => "off",
-					id           => "score_problem$grader->{problem_id}",
-					class        => "problem-score form-control form-control-sm d-inline",
-					data         => { problem_id => $grader->{problem_id} } =%>
+				<div class="col-sm">
+					% param('grader-problem-score', wwRound(0, $grader->{recorded_score} * 100));
+					<%= number_field 'grader-problem-score' => '',
+						min          => 0,
+						max          => 100,
+						autocomplete => "off",
+						id           => "score_problem$grader->{problem_id}",
+						class        => "problem-score form-control form-control-sm d-inline",
+						data         => { problem_id => $grader->{problem_id} } =%>
+				</div>
 			</div>
-		</div>
+		% }
 
 		% # Instructor comment
 		% if ($grader->{past_answer_id}) {

--- a/templates/HTML/SingleProblemGrader/grader.html.ep
+++ b/templates/HTML/SingleProblemGrader/grader.html.ep
@@ -61,6 +61,44 @@
 			% }
 		% }
 
+		% # Total point value. Hide unless point value > 1.
+		% if ($grader->{problem_value} > 1) {
+			<div class="row align-items-center mb-2">
+				<%= label_for "score_problem$grader->{problem_id}_points",
+					class => 'col-fixed col-form-label',
+					begin =%>
+					<%= maketext('Point Value (0 - [_1]):', $grader->{problem_value}) %>
+					<%= link_to '#',
+						class => 'help-popup',
+						data => {
+							bs_content => maketext(
+								'The initial value is the total number points for the answer(s) that are '
+								. 'currently shown.  If this is modified, it will be used to compute the '
+								. 'total problem score below.  This score is not saved, and will be reset '
+								. 'to the score for the shown answer(s) if the page is reloaded.'
+							),
+							bs_placement => 'top',
+							bs_toggle    => 'popover'
+						},
+						begin =%>
+						<i class="icon fas fa-question-circle" aria-hidden="true" data-alt="Help Icon"></i>
+						<span class="sr-only-glyphicon">Help Icon</span>
+					<% end =%>
+				<% end =%>
+				<div class="col-sm">
+					% param('grader-problem-points',  wwRound(1, $grader->{recorded_score} * $grader->{problem_value}));
+					<%= number_field 'grader-problem-points' => '',
+						min          => 0,
+						max          => $grader->{problem_value},
+						step         => 0.1,
+						autocomplete => 'off',
+						id           => "score_problem$grader->{problem_id}_points",
+						class        => "problem-points form-control form-control-sm d-inline",
+						data         => { problem_id => $grader->{problem_id} } =%>
+				</div>
+			</div>
+		% }
+
 		% # Total problem score
 		<div class="row align-items-center mb-2">
 			<%= label_for "score_problem$grader->{problem_id}",


### PR DESCRIPTION
When the problemGraderScore is set to Points, instead of adding the percent input with label, help, and all of the html markup that will not be used and should not be in the DOM, just add a hidden input for the percent score in this case.

Also change some variable names to be more meaningful as to what they represent.

Finally, fix alerts.  The bootstrap `alert` class adds padding and margins and such that are not desired here and so the necessary css was previously added in math4.scss.  However, bootstrap has changed the `alert` class css and so the css added in math4.scss needs to be updated.