### PR TITLE
Update the checkbox handling for the PG problem editor save form.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -599,7 +599,7 @@ sub backupFile ($c, $outputFilePath) {
 	}
 }
 
-sub saveFileChanges ($c, $outputFilePath, $backup = undef) {
+sub saveFileChanges ($c, $outputFilePath, $backup = 0) {
 	my $ce              = $c->ce;
 	my $problemContents = ${ $c->{r_problemContents} };
 
@@ -947,7 +947,7 @@ sub save_handler ($c) {
 				. 'The problem set may have changed. Please reopen this file from the homework sets editor.'
 		));
 	} else {
-		$c->saveFileChanges($c->{editFilePath}, $c->param('backupFile'));
+		$c->saveFileChanges($c->{editFilePath}, scalar($c->param('backupFile')));
 	}
 
 	# Don't redirect unless it was requested to open in a new window.

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/save_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/save_form.html.ep
@@ -16,7 +16,9 @@
 	% my $backupMax = $c->ce->{options}{editorNumberOfBackups};
 	% if ($backupMax > 0) {
 		<div class="form-check mb-2">
-			<%= check_box backupFile => 1, id => 'backupFile', class => 'form-check-input', checked => undef =%>
+			% param('backupFile', 1) unless defined param('backupFile');
+			<%= check_box backupFile => 1, id => 'backupFile', class => 'form-check-input' =%>
+			<%= hidden_field backupFile => 0 =%>
 			<%= label_for backupFile => maketext('Create backup'), class => 'form-check-label' =%>
 		</div>
 


### PR DESCRIPTION
This makes it so that the 'Create backup' checkbox is checked when the page loads initially, but maintains the status that the user set it to on any page submission.  Currently it is simply always checked which is not intuitive.

The 'Delete oldest backup' checkbox always maintains the current status set by the user unless the maximum number of backups has been reached. From then on it is always checked, and the user must manually uncheck it.

You mentioned that you want to reset the radio buttons in the revert form also.  That shouldn't be done.  In general, form checks and radios should come back after a form submission with the same status they had at the time the form was submitted unless there is a good reason that should be changed.

For the radio buttons there is no good reason to reset them.

For the 'Create backup' checkbox there is certainly no good reason to change it from what the user set it to.  There it is even a bad thing to do so.  If the user specifically unchecked it, not wanted a backup, then you should assume the user does not want a backup the next time as well.  If the user wants a backup, it is their choice to check it again.

For the 'Delete oldest backup' checkbox, that status should be maintained also.  However, if the max backup number is reached, then we are saying that we want it deleted so we nudge the user to do so by checking it.

Although, I am rethinking the course configuration option for this.  With options built into the editor for when a backup is saved and deleted, that is really not needed.  I think that should be removed.