### PR TITLE
Revert tab appears by javascript.

### DIFF
--- a/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
@@ -43,6 +43,10 @@
 
 		if (!request_object.outputFilePath) return;
 
+		document.getElementById('action_revert_type_revert_id').disabled = false;
+		document.getElementById('revert-to-tmp-container')?.classList.remove('d-none');
+		document.getElementById('revert-tab')?.classList.remove('disabled');
+
 		fetch(webserviceURL, { method: 'post', mode: 'same-origin', body: new URLSearchParams(request_object) })
 			.then((response) => response.json())
 			.then((data) => showMessage(data.server_response, data.result_data))
@@ -78,6 +82,10 @@
 
 		if (actionView && actionView.classList.contains('active')) {
 			if (document.getElementById('newWindowView')?.checked) {
+				document.getElementById('action_revert_type_revert_id').disabled = false;
+				document.getElementById('revert-to-tmp-container')?.classList.remove('d-none');
+				document.getElementById('revert-tab')?.classList.remove('disabled');
+
 				if (editorForm) editorForm.target = 'WW_View';
 			} else {
 				e.preventDefault();
@@ -92,7 +100,16 @@
 			&& actionSave.classList.contains('active')
 			&& document.getElementById('newWindowSave')?.checked
 			&& editorForm)
+		{
+			if (document.getElementById('backupFile')?.checked) {
+				document.getElementById('show-backups-comment')?.classList.remove('d-none');
+				const deleteBackupCheck = document.getElementById('deleteBackup');
+				if (deleteBackupCheck) deleteBackupCheck.disabled = false;
+			}
+			document.getElementById('revert-tab')?.classList.remove('disabled');
+
 			editorForm.target = 'WW_View';
+		}
 
 
 		const actionHardcopy = document.getElementById('hardcopy');

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -566,7 +566,9 @@ sub getFilePaths ($c) {
 
 sub getBackupTimes ($c) {
 	my $backBasePath = $c->{backBasePath};
-	return reverse(map { $_ =~ s/$backBasePath//r } glob("$backBasePath*"));
+	my @files        = glob("$backBasePath*");
+	return unless @files;
+	return reverse(map { $_ =~ s/$backBasePath//r } @files);
 }
 
 sub backupFile ($c, $outputFilePath) {

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -146,13 +146,17 @@
 	% for my $actionID (@$formsToShow) {
 		% my $line_contents = include("ContentGenerator/Instructor/PGProblemEditor/${actionID}_form");
 		% my $active        = '';
+		% my $disabled =
+			% $actionID eq 'revert'
+			% && (!defined($c->{tempFilePath}) || !-e $c->{tempFilePath})
+			% && !$c->getBackupTimes ? ' disabled' : '';
 		%
-		% if ($line_contents && $line_contents ne '') {
+		% if (($line_contents && $line_contents ne '') || $actionID eq 'revert') {
 			% unless ($default_choice) { $active = ' active'; $default_choice = $actionID; }
 			% content_for 'tab-list' => begin
 				<li class="nav-item" role="presentation">
 					<%= link_to maketext($actionFormTitles->{$actionID}) => "#$actionID",
-						class           => "nav-link action-link$active",
+						class           => "nav-link action-link$active$disabled",
 						id              => "$actionID-tab",
 						data            => { action => $actionID, bs_toggle => 'tab', bs_target => "#$actionID" },
 						role            => 'tab',

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
@@ -18,15 +18,13 @@
 			<%= maketext('Select action:') %>
 		</div>
 
-		% if ($foundTempFile) {
-			<div class="form-check mb-2">
-				<%= radio_button 'action.revert.type' => 'revert', id => 'action_revert_type_revert_id',
-					checked => undef, class => 'form-check-input' =%>
-				<%= label_for 'action_revert_type_revert_id', class => 'form-check-label', begin =%>
-					<%== maketext('Revert to [_1]', tag('span', dir => 'ltr', $c->shortPath($c->{editFilePath}))) =%>
-				<% end =%>
-			</div>
-		% }
+		<div class="form-check mb-2<%= $foundTempFile ? '' : ' d-none' %>" id="revert-to-tmp-container">
+			<%= radio_button 'action.revert.type' => 'revert', id => 'action_revert_type_revert_id',
+				checked => undef, class => 'form-check-input' =%>
+			<%= label_for 'action_revert_type_revert_id', class => 'form-check-label', begin =%>
+				<%== maketext('Revert to [_1]', tag('span', dir => 'ltr', $c->shortPath($c->{editFilePath}))) =%>
+			<% end =%>
+		</div>
 
 		<div class="row align-items-center mb-2">
 			<div class="col-auto">
@@ -78,9 +76,14 @@
 			% }
 		</div>
 	</div>
-% } elsif ($foundTempFile) {
-	<div class="mb-2">
+% } else {
+	<div class="mb-2<%= $foundTempFile ? '' : ' d-none' %>" id="revert-to-tmp-container">
 		<%== maketext('Revert to [_1]', tag('span', dir => 'ltr', $c->shortPath($c->{editFilePath}))) =%>
+		<%= hidden_field 'action.revert.type' => 'revert', id => 'action_revert_type_revert_id',
+			$foundTempFile ? () : (disabled => undef) =%>
 	</div>
-	<%= hidden_field 'action.revert.type' => 'revert' =%>
+	<div class="mb-2 d-none" id="show-backups-comment">
+		<%== maketext('Reload the page to see backup files that have been made.') =%>
+	</div>
+
 % }

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/save_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/save_form.html.ep
@@ -22,12 +22,10 @@
 
 		% # Show option to delete oldest backup if it exists. Check option if at backup capacity.
 		% my @backupTimes = $c->getBackupTimes;
-		% if (@backupTimes) {
-			<div class="form-check mb-2">
-				<%= check_box deleteBackup => 1, id => 'deleteBackup', class => 'form-check-input',
-					scalar(@backupTimes) < $backupMax ? () : (checked => undef) =%>
-				<%= label_for deleteBackup => maketext('Delete oldest backup'), class => 'form-check-label' =%>
-			</div>
-		% }
+		<div class="form-check mb-2">
+			<%= check_box deleteBackup => 1, id => 'deleteBackup', class => 'form-check-input',
+				@backupTimes < $backupMax ? () : (checked => undef), @backupTimes ? () : (disabled => undef) =%>
+			<%= label_for deleteBackup => maketext('Delete oldest backup'), class => 'form-check-label' =%>
+		</div>
 	% }
 </div>


### PR DESCRIPTION
Make the revert tab on the PG problem editor page always there.  However, it is disabled if there is nothing to revert to.  When a temporary file is saved by javascript, then it is enabled by javascript.

I decide to take another stab at this.  Before I was trying to make the revert tab not visible initially.  This approach just makes it disabled.  That is not quite as hard.  Although it is a bit annoying with the special case and check that needs to be made when the action forms are loaded.