### PR TITLE
Make the backup radio button checked after reverting the tmp file

### DIFF
--- a/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
@@ -43,9 +43,13 @@
 
 		if (!request_object.outputFilePath) return;
 
-		document.getElementById('action_revert_type_revert_id').disabled = false;
 		document.getElementById('revert-to-tmp-container')?.classList.remove('d-none');
 		document.getElementById('revert-tab')?.classList.remove('disabled');
+		const revertRadio = document.getElementById('action_revert_type_revert_id');
+		if (revertRadio && revertRadio.disabled) {
+			revertRadio.disabled = false;
+			revertRadio.checked = true;
+		}
 
 		fetch(webserviceURL, { method: 'post', mode: 'same-origin', body: new URLSearchParams(request_object) })
 			.then((response) => response.json())
@@ -73,6 +77,17 @@
 		});
 	}
 
+	const revertBackupCheck = document.getElementById('action_revert_type_backup_id');
+	if (revertBackupCheck) {
+		document.getElementById('action_revert_backup_time_id')
+			?.addEventListener('change', () => revertBackupCheck.checked = true);
+	}
+	const deleteBackupCheck = document.getElementById('action_revert_type_delete_id');
+	if (deleteBackupCheck) {
+		document.getElementById('action_revert_delete_number_id')
+			?.addEventListener('change', () => deleteBackupCheck.checked = true);
+	}
+
 	document.getElementById('submit_button_id')?.addEventListener('click', async (e) => {
 		const actionView = document.getElementById('view');
 		const editorForm = document.getElementById('editor');
@@ -82,9 +97,13 @@
 
 		if (actionView && actionView.classList.contains('active')) {
 			if (document.getElementById('newWindowView')?.checked) {
-				document.getElementById('action_revert_type_revert_id').disabled = false;
-				document.getElementById('revert-to-tmp-container')?.classList.remove('d-none');
 				document.getElementById('revert-tab')?.classList.remove('disabled');
+				document.getElementById('revert-to-tmp-container')?.classList.remove('d-none');
+				const revertRadio = document.getElementById('action_revert_type_revert_id');
+				if (revertRadio && revertRadio.disabled) {
+					revertRadio.disabled = false;
+					revertRadio.checked = true;
+				}
 
 				if (editorForm) editorForm.target = 'WW_View';
 			} else {

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
@@ -28,8 +28,10 @@
 
 		<div class="row align-items-center mb-2">
 			<div class="col-auto">
+				% param('action.revert.type', 'backup')
+					% if !$foundTempFile && (param('action.revert.type') // '') eq 'revert';
 				<%= radio_button 'action.revert.type' => 'backup', id => 'action_revert_type_backup_id',
-					class => 'form-check-input', $foundTempFile ? () : (checked => undef) =%>
+					class => 'form-check-input' =%>
 				<%= label_for 'action_revert_type_backup_id', class => 'form-check-label ms-2', begin =%>
 					<%= scalar(@backupTimes) == 1
 						? maketext(

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
@@ -20,7 +20,7 @@
 
 		<div class="form-check mb-2<%= $foundTempFile ? '' : ' d-none' %>" id="revert-to-tmp-container">
 			<%= radio_button 'action.revert.type' => 'revert', id => 'action_revert_type_revert_id',
-				checked => undef, class => 'form-check-input' =%>
+				checked => undef, class => 'form-check-input', $foundTempFile ? () : (disabled => undef) =%>
 			<%= label_for 'action_revert_type_revert_id', class => 'form-check-label', begin =%>
 				<%== maketext('Revert to [_1]', tag('span', dir => 'ltr', $c->shortPath($c->{editFilePath}))) =%>
 			<% end =%>
@@ -29,7 +29,7 @@
 		<div class="row align-items-center mb-2">
 			<div class="col-auto">
 				% param('action.revert.type', 'backup')
-					% if !$foundTempFile && (param('action.revert.type') // '') eq 'revert';
+					% if !$foundTempFile && (!param('action.revert.type') || param('action.revert.type') eq 'revert');
 				<%= radio_button 'action.revert.type' => 'backup', id => 'action_revert_type_backup_id',
 					class => 'form-check-input' =%>
 				<%= label_for 'action_revert_type_backup_id', class => 'form-check-label ms-2', begin =%>
@@ -55,7 +55,7 @@
 
 		<div class="row align-items-center mb-2">
 			<div class="col-auto">
-				<%= radio_button 'action.revert.type' => 'delete', id => "action_revert_type_delete_id",
+				<%= radio_button 'action.revert.type' => 'delete', id => 'action_revert_type_delete_id',
 					class => 'form-check-input' =%>
 				<%= label_for "action_revert_type_delete_id", class => 'form-check-label ms-2', begin =%>
 					<%= scalar(@backupTimes) == 1


### PR DESCRIPTION
This should fix the issue with the radio button after reverting the temporary file.

I also noticed that if backup files exist and a temporary file does not when the page is initially opened, then if a temporary file is created (by the view/reload action in the same window for instance), then the restore backup radio is still checked, and not the revert radio.  Should javascript switch that?