### PR TITLE
Fix too long lines in defaults.config

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1575,9 +1575,9 @@ $ConfigValues = [
 			doc  => x('Number of backups to keep in the PG editor (0 to disable backups)'),
 			doc2 => x(
 					'If this is greater than zero, two additional options become available when saving files with '
-					. 'the problem editor, backup previous file and delete oldest backup. This sets the number of backups '
-					. 'to keep before suggesting to delete the oldest backup. Backup files can be either restored or '
-					. 'deleted under the "Revert" tab. Setting to 0 disables all backup features.'
+					. 'the problem editor, backup previous file and delete oldest backup. This sets the number of '
+					. 'backups to keep before suggesting to delete the oldest backup. Backup files can be either '
+					. 'restored or deleted under the "Revert" tab. Setting to 0 disables all backup features.'
 			),
 			type => 'number'
 		},


### PR DESCRIPTION
@somiaj: If the editorNumberOfBackups option is going to stay, then the documentation needs to be fixed.  One line exceeds the 120 character limit.