### PR TITLE
Use the empty string for the "None" values and don't save "None" to the database (and other clean up).

### DIFF
--- a/templates/ContentGenerator/Instructor/SendMail.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail.html.ep
@@ -30,7 +30,6 @@
 			</i>
 		% end
 		% $c->addgoodmessage($message->());
-		% $c->{message} = $message->();
 	% }
 	%
 	<%= include('ContentGenerator/Instructor/SendMail/main_form') =%>

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -13,8 +13,9 @@
 							<strong><%= maketext('Message file:') %></strong>
 						<% end =%>
 						<%= select_field openfilename => [
+								[ None => '' ],
 								map { [ $_ => $_, $_ eq $c->{input_file} ? (selected => undef) : () ] }
-								('None', $c->get_message_file_names)
+								$c->get_message_file_names
 							],
 							id => 'openfilename', class => 'form-select form-select-sm' =%>
 					</div>
@@ -23,6 +24,7 @@
 							<strong><%= maketext('Merge file:') %></strong>
 						<% end =%>
 						<%= select_field merge_file => [
+								[ None => '' ],
 								map { [ $_ => $_, $_ eq $c->{merge_file} ? (selected => undef) : () ] }
 								$c->get_merge_file_names
 							],
@@ -141,7 +143,7 @@
 	</div>
 	%
 	% # Show valid rows of selected merge file.
-	% if ($c->{merge_file} ne 'None') {
+	% if ($c->{merge_file}) {
 		<div class="mb-2"><%= maketext('Showing data from merge file: [_1]', $c->{merge_file}) =%></div>
 		% my $rh_merge_data = $c->read_scoring_file($c->{merge_file});
 		% my @rows;
@@ -174,7 +176,7 @@
 	% # Save buttons
 	<div class="card">
 		<div class="card-body p-1 d-md-flex flex-wrap justify-content-evenly">
-			% if ($c->{input_file} ne 'None') {
+			% if ($c->{input_file}) {
 				<div class="input-group input-group-sm w-auto m-1">
 					<%= submit_button maketext('Save'), name => 'saveMessage', class => 'btn btn-secondary btn-sm' =%>
 					<span class="input-group-text">


### PR DESCRIPTION
I don't like saving the "None" value to the database.  Furthermore, it is almost always the case that a default select value is better handled with an empty value.  This is not an exception.

@somiaj:  Note that if you have 'None' saved in the database from when you were saving this to the database, you will get a warning on the page about that file not existing.  That will go away once you toggle settings and it is removed from the database.

Clean up some of the mess of `if (defined $var && $var)` conditionals.  For values that are expected to one of undef, the empty string, or some nonempty string it is equivalent and much cleaner to just check `if ($var)`.

Fix some of the 'Save as' messages.  Currently if no filename is specified you get the message
	No filename was specified for saving! The message was not saved.
and then you also are given the message
	Invalid file name "FIXME no output file specified". All email
	file names must end with the ".msg" extension. Choose a file
	name with the ".msg" extension. The message was not saved.
which really doesn't make sense.

Remove the setting of $c->{message}.  It turns out that was still set. The display of that message has been deleted, and it really isn't needed anymore.