### PR TITLE
Set the preview user when the page loads.

### DIFF
--- a/htdocs/js/apps/SendMail/sendmail.js
+++ b/htdocs/js/apps/SendMail/sendmail.js
@@ -1,12 +1,17 @@
 (() => {
 	const previewUserNameSpan = document.getElementById('preview-user');
-	if (previewUserNameSpan) {
-		const classListSelect = document.getElementById('classList');
-		classListSelect?.addEventListener('change', () => {
+	const classListSelect = document.getElementById('classList');
+	if (previewUserNameSpan && classListSelect) {
+		const setPreviewUser = () => {
 			if (classListSelect.selectedIndex !== -1)
 				previewUserNameSpan.textContent = classListSelect.options[classListSelect.selectedIndex].textContent;
 			else previewUserNameSpan.textContent = previewUserNameSpan.dataset.default;
-		});
+		};
+		classListSelect.addEventListener('change', setPreviewUser);
+
+		// The timeout should not be needed.  For some reason the classList select is not set correctly on Google
+		// Chrome when the page first loads after the back button is pressed, and it takes a bit for it to be set.
+		setTimeout(setPreviewUser, 100);
 	}
 
 	for (const select of [


### PR DESCRIPTION
This is done after a 100 ms timeout due to what seems to be a bug on Google Chrome.  The value of the class list select is not set immediately on page load after the back button is pressed, and it takes a bit for it to be set.