### PR TITLE
Somiaj new grades page

### DIFF
--- a/htdocs/js/Grades/grades.scss
+++ b/htdocs/js/Grades/grades.scss
@@ -41,6 +41,23 @@
 	grid-column: 2 / 3;
 }
 
-.problem-table th {
-	min-width: 2rem;
+.problem-table {
+	th {
+		min-width: 2rem;
+	}
+	caption {
+		width: max-content;
+	}
+}
+
+#toggle-weights,
+#toggle-attempts,
+.weights-row,
+.attempts-row {
+	display: none;
+}
+
+#toggle-weights:checked ~ .list-group .weights-row,
+#toggle-attempts:checked ~ .list-group .attempts-row {
+	display: table-row;
 }

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -308,6 +308,7 @@ sub displayStudentGrades ($c) {
 				|| $authz->invalidIPAddress($set);
 
 			for my $i (0 .. $#$problem_scores) {
+				my $value      = $problem_records->[$i]{value};
 				my $score      = $problem_scores->[$i];
 				my $problem_id = $setIsVersioned ? $i + 1 : $problem_records->[$i]{problem_id};
 				my $attempts = $setIsTest ? 0 : $problem_incorrect_attempts->[$i] + $problem_records->[$i]->num_correct;
@@ -324,13 +325,25 @@ sub displayStudentGrades ($c) {
 					if ($#seq == 0) {
 						push(
 							@{ $item->{problems} },
-							{ id => $seq[0], score => $score, link => $problem_link, attempts => $attempts }
+							{
+								id       => $seq[0],
+								score    => $score,
+								link     => $problem_link,
+								attempts => $attempts,
+								value    => $value
+							}
 						);
 					}
 				} else {
 					push(
 						@{ $item->{problems} },
-						{ id => $problem_id, score => $score, link => $problem_link, attempts => $attempts }
+						{
+							id       => $problem_id,
+							score    => $score,
+							link     => $problem_link,
+							attempts => $attempts,
+							value    => $value
+						}
 					);
 				}
 			}

--- a/templates/ContentGenerator/Grades/problem_table.html.ep
+++ b/templates/ContentGenerator/Grades/problem_table.html.ep
@@ -43,19 +43,25 @@
 				</td>
 			% }
 		</tr>
-		<tr>
-			<th class="text-start" scope="row"><%= maketext('Status (%)') %></th>
+		<tr class="weights-row">
+			<th class="text-start" scope="row"><%= maketext('Weight') %></th>
 			% for my $problem (@problems) {
-				<td><%= $problem->{score} %></td>
+				<td><%= $problem->{value} %></td>
 			% }
 		</tr>
 		% unless ($item->{version_count}) {
-			<tr>
+			<tr class="attempts-row">
 				<th class="text-start" scope="row"><%= maketext('Attempts') %></th>
 				% for my $problem (@problems) {
 					<td><%= $problem->{attempts} %></td>
 				% }
 			</tr>
 		% }
+		<tr>
+			<th class="text-start" scope="row"><%= maketext('Status (%)') %></th>
+			% for my $problem (@problems) {
+				<td><%= $problem->{score} %></td>
+			% }
+		</tr>
 	</tbody>
 </table>

--- a/templates/ContentGenerator/Grades/problem_table.html.ep
+++ b/templates/ContentGenerator/Grades/problem_table.html.ep
@@ -11,22 +11,22 @@
 %
 <table class="problem-table table table-sm table-bordered caption-top font-sm text-center w-auto mb-0">
 	<caption class="small p-0">
+		<%= maketext('Score: [_1] out of [_2]', $item->{grade_total_right}, $item->{grade_total}) %>
 		% if ($item->{version_id}) {
 			% if ($item->{version_link}) {
 				<a class="fw-bold" href="<%= $item->{version_link} %>">
 			% }
 			% if ($item->{version_count} > 1) {
-				<%= maketext('Version [_1] of [_2] versions taken',
+				<%= maketext('for version [_1] of [_2] versions taken',
 					$item->{version_id}, $item->{version_count}) %>
 			% } else {
-				<%= maketext('Version [_1]', $item->{version_id}) %>
+				<%= maketext('for version [_1]', $item->{version_id}) %>
 			% }
 			% if ($item->{version_link}) {
 				</a>
 			% }
 			<br>
 		% }
-		<%= maketext('Score: [_1] out of [_2]', $item->{grade_total_right}, $item->{grade_total}) %>
 	</caption>
 	<tbody>
 		<tr>

--- a/templates/ContentGenerator/Grades/student_grades.html.ep
+++ b/templates/ContentGenerator/Grades/student_grades.html.ep
@@ -18,7 +18,12 @@
 		</div>
 	</div>
 % }
-%
+% if (@$open || @$reduced || @$closed) {
+	<input type="checkbox" id="toggle-weights">
+	<label for="toggle-weights" class="btn btn-secondary my-3"><%= maketext('Show/Hide Weights') %></label>
+	<input type="checkbox" id="toggle-attempts">
+	<label for="toggle-attempts" class="btn btn-secondary my-3"><%= maketext('Show/Hide Attempts') %></label>
+% }
 % if (@$open) {
 	<h2><%= maketext('Open Assignments') %></h2>
 	<%= include('ContentGenerator/Grades/grade_items', items => $open) %>


### PR DESCRIPTION
What do you think about these?

1.  For a test, move the overall score report and the report of which version is the relevant version all to one line. For example, the second assignment here:

<img width="477" height="210" alt="Screenshot 2026-05-20 at 5 27 34 PM" src="https://github.com/user-attachments/assets/e8d32904-9268-4d58-8ff5-76dcada67c36" />

2.  Add a row to the tables to show the weights of each problem. But before objecting to the excess space this takes up...
3.  Add toggles to reveal weights and attempt counts:

<img width="480" height="563" alt="Screenshot 2026-05-20 at 5 29 11 PM" src="https://github.com/user-attachments/assets/74731171-4494-40ef-8370-e69ad12fe4b9" />

Those rows are hidden by default as in the first screenshot. No javascript is used for this, just css.
